### PR TITLE
Explicitly require heyoka 2.*.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,12 +177,8 @@ find_package(fmt CONFIG REQUIRED)
 target_link_libraries(kep3 PUBLIC fmt::fmt)
 
 # heyoka.
-find_package(heyoka CONFIG REQUIRED)
+find_package(heyoka 2.0.0 REQUIRED CONFIG)
 target_link_libraries(kep3 PUBLIC heyoka::heyoka)
-message(STATUS "heyoka version: ${heyoka_VERSION}")
-if(heyoka_VERSION VERSION_LESS 0.21.0)
-    message(FATAL_ERROR "heyoka>=0.21.0 is required, but heyoka ${heyoka_VERSION} was found instead")
-endif()
 
 # spdlog.
 find_package(spdlog CONFIG REQUIRED)

--- a/kep3-config.cmake.in
+++ b/kep3-config.cmake.in
@@ -1,7 +1,7 @@
 # Mandatory public dependencies on Boost and fmt.
 find_package(Boost @_kep3_MIN_BOOST_VERSION@ REQUIRED serialization)
 find_package(fmt REQUIRED CONFIG)
-find_package(heyoka REQUIRED CONFIG)
+find_package(heyoka 2.0.0 REQUIRED CONFIG)
 find_package(xtensor REQUIRED CONFIG)
 find_package(xtensor-blas REQUIRED CONFIG)
 

--- a/kep3_devel.yml
+++ b/kep3_devel.yml
@@ -8,7 +8,7 @@ dependencies:
   - cmake >=3.18
   - boost-cpp >=1.73
   - fmt
-  - heyoka >=0.21.0
+  - heyoka =2.*
   - spdlog
   - xtensor
   - xtensor-blas


### PR DESCRIPTION
heyoka now uses semantic versioning, so let us be specific about the API version we want.