### PR TITLE
(WIP) Leap-Seconds

### DIFF
--- a/include/kep3/epoch.hpp
+++ b/include/kep3/epoch.hpp
@@ -100,6 +100,8 @@ class kep3_DLL_PUBLIC epoch
     static time_point make_tp(int y, unsigned mon, unsigned d, std::int32_t h = 0, std::int32_t min = 0,
                               std::int32_t s = 0, std::int32_t ms = 0, std::int32_t us = 0);
 
+    static time_point tp_from_days(double days);
+
 public:
     enum class julian_type { MJD2000, MJD, JD };
     enum class string_format { ISO };
@@ -116,17 +118,6 @@ public:
 
     // Constructor from time point.
     explicit epoch(time_point);
-
-    /**
-     * Constructs an epoch from a std::chrono::duration.
-     * The reference point is assumed to be MJD2000.
-     * \param[in] time The time as a duration.
-     */
-    template <typename Rep, typename Period>
-    explicit epoch(std::chrono::duration<Rep, Period> duration)
-        : m_tp{std::chrono::duration_cast<microseconds>(duration)}
-    {
-    }
 
     // Constructor for datetime broken down into its constituents.
     explicit epoch(int y, unsigned mon, unsigned d, std::int32_t h = 0, std::int32_t min = 0, std::int32_t s = 0,
@@ -159,9 +150,6 @@ public:
     {
         return std::chrono::duration<double, seconds_day_ratio>(m_tp.time_since_epoch() - y2k_offset).count();
     }
-
-    // Conversions
-    static time_point tp_from_days(double days);
 
     // Duration conversions
     static constexpr double as_sec(const microseconds &d)

--- a/test/epoch_test.cpp
+++ b/test/epoch_test.cpp
@@ -77,8 +77,6 @@ TEST_CASE("construct")
 
 TEST_CASE("epoch_operators")
 {
-    epoch(std::chrono::nanoseconds(10));
-
     REQUIRE(epoch(2034, 10, 17) == epoch(2034, 10, 17));
     REQUIRE(epoch(2034, 10, 17) != epoch(2034, 11, 17));
     // Testing us precision

--- a/test/epoch_test.cpp
+++ b/test/epoch_test.cpp
@@ -16,6 +16,7 @@
 #include <fmt/chrono.h>
 #include <fmt/core.h>
 
+#include <kep3/core_astro/constants.hpp>
 #include <kep3/epoch.hpp>
 
 #include "catch.hpp"
@@ -113,6 +114,32 @@ TEST_CASE("epoch_operators")
 TEST_CASE("epoch_now")
 {
     REQUIRE_NOTHROW(kep3::epoch::now());
+}
+
+TEST_CASE("leap_seconds_tests")
+{
+    {
+        kep3::epoch ep1{2005, 12, 31, 23, 59, 59};
+        kep3::epoch ep2{2006, 1, 1, 00, 00, 00};
+        {
+            // Here we check that a leap second is accounted for at the beginning of 2005 when subtracting epochs.
+            REQUIRE(((ep2 - ep1).count() / 1000000lu) == 2lu);
+        }
+        {
+            // Here we check that epochs are correctly transformed into julian dates.
+            REQUIRE((ep2.jd() - ep1.jd()) * kep3::DAY2SEC == 2);
+            REQUIRE((ep2.mjd() - ep1.mjd()) * kep3::DAY2SEC == 2);
+            REQUIRE((ep2.mjd2000() - ep1.mjd2000()) * kep3::DAY2SEC == 2);
+        }
+        {
+            // Here we check the as_sec()
+            REQUIRE(kep3::epoch::as_sec(ep2 - ep1) == 2);
+        }
+        {
+            // Here we check the date changes correctly by 1 second when adding 2 seconds (one being the leap).
+            REQUIRE(ep1 + std::chrono::duration<double, std::ratio<86400>>(2) * kep3::SEC2DAY == ep2);
+        }
+    }
 }
 
 TEST_CASE("serialization_test")


### PR DESCRIPTION
In the attempt to have leap seconds correctly accounted for in pykep, this PR adds a number of tests in the c++ side that should pass but do not.

Any attempt to fix the leap second issue should tackle these tests